### PR TITLE
Feature/4 docker image does not include git which is required for setuptools scm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM fedora:34 as base
 
 RUN dnf -y update && dnf clean all
-RUN dnf -y install python3.6 python3.7 python3.8 python3.9 python3.10 pypy3 tox && dnf clean all
-RUN python3 -m pip install --upgrade build twine git mkdocs && dnf clean all
+RUN dnf -y install python3.6 python3.7 python3.8 python3.9 python3.10 pypy3 tox git && dnf clean all
+RUN python3 -m pip install --upgrade build twine mkdocs && dnf clean all
 
 FROM base as build
 ADD . /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:34 as base
 
 RUN dnf -y update && dnf clean all
 RUN dnf -y install python3.6 python3.7 python3.8 python3.9 python3.10 pypy3 tox && dnf clean all
-RUN python3 -m pip install --upgrade build twine mkdocs && dnf clean all
+RUN python3 -m pip install --upgrade build twine git mkdocs && dnf clean all
 
 FROM base as build
 ADD . /src


### PR DESCRIPTION
Without git installed in the docker image, `make ci` fails with an error about missing git. This PR adds git to the test environment. 

closes #4 