### PR TITLE
Remove the explicit version number from pyproject.toml

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pytest_netdut
-version = 0.1.0
 url=https://github.com/aristanetworks/pytest-netdut
 
 description = "Automated software testing for switches using pytest"


### PR DESCRIPTION
We should not have an explicit version number set. 

closes #11 