### PR TITLE
Feature/BS 962 fix dut fixture global names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,10 +24,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest tox
-      
+
       - name: Test using tox
         run: |
-          tox -s -e "py37,py38,py39,py310"
+          tox -s -e "py37,py38,py39,py310,py311"
 
 #      - name: Test Summary
 #        uses: test-summary/action@v1
@@ -35,7 +35,7 @@ jobs:
 #          paths: |
 #            test-reports/*.xml
 #        if: always()
-  
+
   lint:
     runs-on: ubuntu-latest
 
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,7 @@
 requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
+[tool.black]
+line-length = 120
+
 [tool.setuptools_scm]

--- a/src/pytest_netdut/__init__.py
+++ b/src/pytest_netdut/__init__.py
@@ -91,9 +91,7 @@ def pytest_configure(config):
     # register markers
     config.addinivalue_line("markers", "eos: mark a test as eos only.")
     config.addinivalue_line("markers", "mos: mark a test as mos only.")
-    config.addinivalue_line(
-        "markers", "skip_device_type: mark a test as excluding a particular SKU regex."
-    )
+    config.addinivalue_line("markers", "skip_device_type: mark a test as excluding a particular SKU regex.")
     config.addinivalue_line(
         "markers",
         "only_device_type: mark a test as only running on a particular SKU regex.",

--- a/src/pytest_netdut/__init__.py
+++ b/src/pytest_netdut/__init__.py
@@ -173,5 +173,6 @@ def dut_info(pytestconfig) -> dict:
     assert info["console_url"] or info["hostname"], "You must specify a device"
     return info
 
+
 logger.debug("Registering `dut`")
 create("dut")

--- a/src/pytest_netdut/__init__.py
+++ b/src/pytest_netdut/__init__.py
@@ -151,8 +151,6 @@ def create(name) -> Callable:
     ]
 
     for fixture in fixtures:
-        logger.info(f"Registering {fixture} as a global")
-        #import pdb; pdb.set_trace()
         globals()[fixture._pytestfixturefunction.name] = fixture
 
     return fixtures[0]
@@ -175,5 +173,5 @@ def dut_info(pytestconfig) -> dict:
     assert info["console_url"] or info["hostname"], "You must specify a device"
     return info
 
-logger.info("Registering DUT")
+logger.debug("Registering `dut`")
 create("dut")

--- a/src/pytest_netdut/__init__.py
+++ b/src/pytest_netdut/__init__.py
@@ -70,12 +70,15 @@ def test_showver(dut):
 
 """
 from typing import Callable
+import logging
 import pytest
 from . import factories
 from .utils import wait_for
 from .wrappers import CLI, EAPI, eapi_enabled_fixture, xapi
 
 __all__ = ["CLI", "EAPI", "create", "eapi_enabled_fixture", "wait_for", "xapi"]
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_configure(config):
@@ -148,7 +151,9 @@ def create(name) -> Callable:
     ]
 
     for fixture in fixtures:
-        globals()[fixture.__name__] = fixture
+        logger.info(f"Registering {fixture} as a global")
+        #import pdb; pdb.set_trace()
+        globals()[fixture._pytestfixturefunction.name] = fixture
 
     return fixtures[0]
 
@@ -170,5 +175,5 @@ def dut_info(pytestconfig) -> dict:
     assert info["console_url"] or info["hostname"], "You must specify a device"
     return info
 
-
+logger.info("Registering DUT")
 create("dut")

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -21,6 +21,7 @@ from .wrappers import CLI, xapi
 
 logger = logging.getLogger(__name__)
 
+
 def create_dut_fixture(name):
     @pytest.fixture(name=f"{name}")
     def _dut(request):

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -79,9 +79,7 @@ def create_skipper_fixture(name):
                     pattern = marker.args[0]
                     sku = request.getfixturevalue(f"{name}_sku")
                     if not re.search(pattern, sku):
-                        pytest.skip(
-                            f"Skipped on this SKU: {sku} (only runs on {pattern})"
-                        )
+                        pytest.skip(f"Skipped on this SKU: {sku} (only runs on {pattern})")
 
                 elif marker.name == "skip_device_type":
                     pattern = marker.args[0]

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -19,9 +19,10 @@ import re
 import pytest
 from .wrappers import CLI, xapi
 
+logger = logging.getLogger(__name__)
 
 def create_dut_fixture(name):
-    @pytest.fixture(scope="session", name=f"{name}")
+    @pytest.fixture(name=f"{name}")
     def _dut(request):
         skipper = request.getfixturevalue(f"{name}_skipper")
         skipper(request.node)


### PR DESCRIPTION
- The DUT fixture's global variable names were not unique enough -- e.g. `_ssh`. We now set the global variable name to be the same as the fixture name. 
- Update the black line length to 120.
- Added Python 3.11 to the test matrix.