### PR TITLE
add min_version and min_change_number

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ def test_that_only_runs_on_eos_on_7130(dut):
 ```
 
 OS decorators accept the following keywords:
- - min_version
- - min_change_number
+ - min_version (string)
+ - min_change_number (int)
 
 If both kwargs are specified, min_change_number takes precedence.
 ```python
-@pytest.mark.eos(min_version="4.30.0", min_change_number="3452345")
+@pytest.mark.eos(min_version="4.30.0", min_change_number=3452345)
 @pytest.mark.skip_device_type("DCS-7130.*")
 def test_that_only_runs_on_eos_on_7130(dut):
     logging.info("Must be EOS on 7130!")

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Netdut: automated software testing for switches using pytest
 ============================================================
 
-![PyPi](https://img.shields.io/pypi/v/pytest-netdut.svg) 
+![PyPi](https://img.shields.io/pypi/v/pytest-netdut.svg)
 ![Python Versions](https://img.shields.io/pypi/pyversions/pytest-netdut.svg)
-![collection version](https://img.shields.io/github/v/release/aristanetworks/pytest-netdut) 
+![collection version](https://img.shields.io/github/v/release/aristanetworks/pytest-netdut)
 ![License](https://img.shields.io/github/license/aristanetworks/pytest-netdut)
 
 Netdut is a [pytest](https://docs.pytest.org/) plugin which provides infrastructure (e.g. pytest fixtures) which make it easy to write automated tests for network switches.
@@ -13,8 +13,8 @@ Features
 --------
 
 * Brings the power, maturity and ecosystem of pytest to testing on network switches.
-* The `dut` fixture (Device Under Test) providing serial, ssh or [EAPI](https://github.com/arista-eosplus/pyeapi) connectivity for running CLI commands on a network switch. 
-* Command-line configuration of a hostname and console name. 
+* The `dut` fixture (Device Under Test) providing serial, ssh or [EAPI](https://github.com/arista-eosplus/pyeapi) connectivity for running CLI commands on a network switch.
+* Command-line configuration of a hostname and console name.
 * Markers for skipping tests based on the device's type or software configuration.
 * Compatibility with both Arista's EOS operating system, and the Metamako MOS operating system.
 * A pythonic interfaces for writing EOS CLI commands.
@@ -156,6 +156,22 @@ def test_that_only_runs_on_eos_on_7130(dut):
     logging.info("Must be EOS on 7130!")
 ```
 
+OS decorators accept the following keywords per OS:
+ - min_version
+ - min_change_number
+
+Expected DUT verison format: ```D.D.D(F|M)-XX-XX-<change_number>```
+I.e. series of dot separated decimals (min_version) and
+the last word after the last dash will be interpreted as the change number.
+
+If both kwargs are specified, min_change_number takes precedence.
+```python
+@pytest.mark.eos(min_version="4.30.0")
+@pytest.mark.skip_device_type("DCS-7130.*")
+def test_that_only_runs_on_eos_on_7130(dut):
+    logging.info("Must be EOS on 7130!")
+```
+
 ### Building test harnesses
 
 Pytest's fixture mechanism is very powerful in this scenario, allowing us to set up and tear
@@ -216,7 +232,7 @@ to snake_case.
 The translator has a predefined set of translations which can be extended by subclassing the Translator class and overriding `config_patterns`.
 Return values are processed by the `translate_key` function which must be defined in the subclass.
 
-Set the new translator class via `eapi.set_translator(<class instance>)`. 
+Set the new translator class via `eapi.set_translator(<class instance>)`.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -160,12 +160,6 @@ OS decorators accept the following keywords:
  - min_version
  - min_change_number
 
-The object must be a python version object
-
-Expected verison format reported by DUT: ```<D.D.D>XX-XX-XX-<change_number>```
-I.e. series of dot separated decimals (min_version) and
-the last word after the last dash will be interpreted as the change number.
-
 If both kwargs are specified, min_change_number takes precedence.
 ```python
 @pytest.mark.eos(min_version="4.30.0", min_change_number="3452345")

--- a/README.md
+++ b/README.md
@@ -156,17 +156,19 @@ def test_that_only_runs_on_eos_on_7130(dut):
     logging.info("Must be EOS on 7130!")
 ```
 
-OS decorators accept the following keywords per OS:
+OS decorators accept the following keywords:
  - min_version
  - min_change_number
 
-Expected DUT verison format: ```<D.D.D>XX-XX-XX-<change_number>```
+The object must be a python version object
+
+Expected verison format reported by DUT: ```<D.D.D>XX-XX-XX-<change_number>```
 I.e. series of dot separated decimals (min_version) and
 the last word after the last dash will be interpreted as the change number.
 
 If both kwargs are specified, min_change_number takes precedence.
 ```python
-@pytest.mark.eos(min_version="4.30.0")
+@pytest.mark.eos(min_version="4.30.0", min_change_number="3452345")
 @pytest.mark.skip_device_type("DCS-7130.*")
 def test_that_only_runs_on_eos_on_7130(dut):
     logging.info("Must be EOS on 7130!")

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ OS decorators accept the following keywords per OS:
  - min_version
  - min_change_number
 
-Expected DUT verison format: ```D.D.D(F|M)-XX-XX-<change_number>```
+Expected DUT verison format: ```<D.D.D>XX-XX-XX-<change_number>```
 I.e. series of dot separated decimals (min_version) and
 the last word after the last dash will be interpreted as the change number.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     pyeapi>=0.8.4
     pytest>=3.5.0
     six>=1.15
+    packaging>=22.0
 
 [options.packages.find]
 where=src

--- a/src/pytest_netdut/__init__.py
+++ b/src/pytest_netdut/__init__.py
@@ -144,6 +144,7 @@ def create(name) -> Callable:
         factories.create_console_url_fixture(name),
         factories.create_skipper_fixture(name),
         factories.create_sku_fixture(name),
+        factories.create_os_version_fixture(name),
         factories.create_softened_fixture(name),
         factories.create_ssh_fixture(name),
         factories.create_xapi_fixture(name),

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -91,8 +91,8 @@ def parse_version(v):
 
 def version_skipper(found, expected):
     try:
-        found = version.Version(found)
-        expected = version.Version(expected)
+        found = version.Version(str(found))
+        expected = version.Version(str(expected))
         if found < expected:
             pytest.skip(f"min_version {expected} not satisfied: {found}")
     except version.InvalidVersion:

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -236,6 +236,9 @@ class _CLI_wrapper:
     def sendintr(self, *args, **kwargs):
         return self._cli.sendintr(*args, **kwargs)
 
+    def prompt(self, *args, **kwargs):
+        return self._cli.prompt(*args, **kwargs)
+
     @property
     def cli_flavor(self):
         return self._cli.cli_flavor

--- a/src/pytest_netdut/factories.py
+++ b/src/pytest_netdut/factories.py
@@ -17,6 +17,7 @@
 import logging
 import re
 import pytest
+from packaging import version
 from .wrappers import CLI, xapi
 
 logger = logging.getLogger(__name__)
@@ -77,11 +78,15 @@ def create_skipper_fixture(name):
     def _skipper(request):
         def skipper(node):
             allowed_os = set()
+            min_version = None
+            min_chg_num = None
 
             # Restrict SKUs
             for marker in node.iter_markers():
                 if marker.name in {"mos", "eos"}:
                     allowed_os.add(marker.name)
+                    min_chg_num = marker.kwargs.get("min_change_number", None)
+                    min_version = marker.kwargs.get("min_version", None)
 
                 elif marker.name == "only_device_type":
                     pattern = marker.args[0]
@@ -95,10 +100,42 @@ def create_skipper_fixture(name):
                     if re.search(pattern, sku):
                         pytest.skip(f"Skipped on this SKU: {sku}")
 
+            def parse_version(v):
+                """Return series of dot separated digits from beginning of string
+                as release and the last group delimited by - as change number."""
+                _regex = r"""
+                    (?P<release>[0-9]+(?:\.[0-9]+)*)
+                    (?:
+                        [-]?
+                        (?P<change_number>[\w]+)
+                    )*
+                """
+                _regex = re.compile(_regex, re.VERBOSE)
+                # _regex = r"(?P<release>[\d\.]*)"
+                parsed = re.match(_regex, v)
+                return (parsed.group("release"), parsed.group("change_number"))
+
+            def version_skipper(found, expected):
+                try:
+                    found = version.Version(found)
+                    expected = version.Version(expected)
+                    if found < expected:
+                        pytest.skip(f"min_version {expected} not satisfied: {found}")
+                except version.InvalidVersion:
+                    logging.error(f"Could not parse versions: {found} < {expected}")
+
             if allowed_os:
                 dut_ssh = request.getfixturevalue(f"{name}_ssh")
+                dut_os_version = request.getfixturevalue(f"{name}_os_version")
                 if dut_ssh.cli_flavor not in allowed_os:
-                    pytest.skip(f"cannot run on platform {dut_ssh.cli_flavor}")
+                    pytest.skip(f"Cannot run on platform {dut_ssh.cli_flavor}")
+                if min_version or min_chg_num:
+                    # matches the pattern X.XX.X.XX with digits only
+                    release, change_number = parse_version(dut_os_version)
+                    if min_chg_num:
+                        version_skipper(change_number, min_chg_num)
+                    else:
+                        version_skipper(release, min_version)
 
         return skipper
 
@@ -116,6 +153,19 @@ def create_sku_fixture(name):
         yield matcher.group(1)
 
     return _sku
+
+
+def create_os_version_fixture(name):
+    @pytest.fixture(scope="session", name=f"{name}_os_version")
+    def _os_version(request):
+        ssh = request.getfixturevalue(f"{name}_ssh")
+        assert ssh.cli_flavor in {"eos", "mos"}
+        output = ssh.sendcmd("show version", timeout=300)
+        matcher = re.search(r"Software image version: (\S*)", output)
+        logging.info("Got OS version: %s", matcher.group(1))
+        yield matcher.group(1)
+
+    return _os_version
 
 
 def create_softened_fixture(name):
@@ -183,9 +233,6 @@ class _CLI_wrapper:
 
     def sendintr(self, *args, **kwargs):
         return self._cli.sendintr(*args, **kwargs)
-
-    def prompt(self, *args, **kwargs):
-        return self._cli.prompt(*args, **kwargs)
 
     @property
     def cli_flavor(self):


### PR DESCRIPTION
OS decorators accept the following keywords per OS:
 - min_version
 - min_change_number

Expected DUT reported verison format: ```<D.D.D>-XX-XX-<change_number>```
I.e. series of dot separated decimals (min_version) and
the last word after the last dash will be interpreted as the change number.

If both kwargs are specified, min_change_number takes precedence.
```python
@pytest.mark.eos(min_version="4.30.0", min_change_number=124817123)
@pytest.mark.skip_device_type("DCS-7130.*")
def test_that_only_runs_on_eos_on_7130(dut):
    logging.info("Must be EOS on 7130!")
```