### PR TITLE
Update fixture creation to handle pytest 8.4.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
 
       - name: Test using tox
         run: |
-          tox -s -e "py37,py38,py39,py310,py311"
+          tox -s -e "py39,py310,py311,py312,py313"
 
   #      - name: Test Summary
   #        uses: test-summary/action@v1
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM fedora:34 AS base
+FROM fedora:42 AS base
 
 RUN dnf -y update && dnf clean all
-RUN dnf -y install python3.7 python3.8 python3.9 python3.10 python3.11 tox git && dnf clean all
+RUN dnf -y install python3.9 python3.10 python3.11 python3.12 python3.13 tox git && dnf clean all
 RUN python3 -m pip install --upgrade build twine mkdocs && dnf clean all
 
 FROM base AS build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features
 Requirements
 ------------
 
-* Requires python3 >= 3.6, pexpect, pyeapi
+* Requires python3 >= 3.9, pexpect, pyeapi
 * Network devices under test (DUTs) must be accessible via SSH.
 
 
@@ -248,4 +248,4 @@ Distributed under the terms of the [BSD-3](http://opensource.org/licenses/BSD-3-
 Issues
 ------
 
-If you encounter any problems, please [file an issue](https://github.com/dcasnowdon-anet/pytest-netdut/issues) along with a detailed description.
+If you encounter any problems, please [file an issue](https://github.com/aristanetworks/pytest-netdut/issues) along with a detailed description.

--- a/src/pytest_netdut/__init__.py
+++ b/src/pytest_netdut/__init__.py
@@ -153,7 +153,11 @@ def create(name) -> Callable:
     ]
 
     for fixture in fixtures:
-        globals()[fixture._pytestfixturefunction.name] = fixture
+        try:
+            globals()[fixture.name] = fixture
+        except AttributeError:
+            # For pytest < 8.4.0
+            globals()[fixture._pytestfixturefunction.name] = fixture
 
     return fixtures[0]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 isolated_build = True
-envlist = py37,py38,py39,py310,py311,black,prospector,tmpblack
+envlist = py39,py310,py311,py312,py313,black,prospector,tmpblack
 
 [testenv]
 deps =


### PR DESCRIPTION
In pytest 8.4.0, a new representation of fixtures was added which broke our fixture creation (see https://github.com/pytest-dev/pytest/pull/12473).

This PR makes `pytest_netdut.create` compatible with the new representation. It also updates the supported Python versions to match upstream.