### PR TITLE
Change wait_for to raise the last exception when it times out

### DIFF
--- a/src/pytest_netdut/utils.py
+++ b/src/pytest_netdut/utils.py
@@ -15,7 +15,6 @@
 # -
 # -------------------------------------------------------------------------------
 
-import contextlib
 import time
 import pexpect
 import pytest
@@ -60,11 +59,12 @@ def wait_for():
         assert timeout > period
 
         if suppress is None:
-            suppress = []
+            suppress = ()
+
         start = time.time()
         while True:
-            with contextlib.suppress(*suppress):
-                result = func()
+            try:
+                result, exception = func(), None
                 if result:
                     elapsed = time.time() - start
                     if elapsed > timeout:
@@ -73,12 +73,20 @@ def wait_for():
                             f"but eventually succeeded after {elapsed} seconds."
                         )
                     return result
+            except Exception as exc:
+                if not isinstance(exc, suppress):
+                    raise exc
+                exception = exc
+
             if time.time() - start > timeout_leeway_factor * timeout:
-                raise pexpect.TIMEOUT(
+                timeout = pexpect.TIMEOUT(
                     f"Function {func} was unsuccessful after the requested {timeout} "
                     f"second timeout, and was also unsuccessful after being allowed "
                     f"a leeway of {timeout_leeway_factor * timeout} seconds."
                 )
+                if exception is not None:
+                    raise exception from timeout
+                raise timeout
             time.sleep(period)
 
     yield _wait_for

--- a/tests/test_wait_for.py
+++ b/tests/test_wait_for.py
@@ -42,6 +42,9 @@ def test_wait_for(wait_for):
         time.sleep(1.1 * TIMEOUT_LEEWAY_FACTOR * TIMEOUT)
         return False
 
+    def except_fn():
+        raise TypeError
+
     # Test a good function which completes within "timeout" (i.e. does not time out)
     # T < timeout
     wait_for(good_fn, timeout=TIMEOUT)
@@ -55,3 +58,16 @@ def test_wait_for(wait_for):
     # T >= TIMEOUT_LEEWAY_FACTOR * timeout
     with pytest.raises(pexpect.TIMEOUT, match=r"unsuccessful"):
         wait_for(bad_fn, timeout=TIMEOUT)
+
+    # Check that exceptions fail immediately if not suppressed
+    with pytest.raises(TypeError):
+        wait_for(except_fn)
+
+    # Check that only the right exceptions are suppressed
+    with pytest.raises(TypeError):
+        wait_for(except_fn, suppress=(ValueError,))
+
+    # Check that suppressed exception will gets raised from the timeout
+    with pytest.raises(TypeError) as exc_info:
+        wait_for(except_fn, timeout=TIMEOUT, suppress=(TypeError,))
+    assert isinstance(exc_info.value.__cause__, pexpect.TIMEOUT)


### PR DESCRIPTION
When wait_for times out, it presently doesn't give much useful information about why. This PR changes its behaviour to report the last suppressed exception when it times out.

This is especially useful if the function it is waiting for is structured as a bunch of asserts because pytest will automatically print the assertion introspection in the traceback. The output will look something like this:

```
================================================ FAILURES =================================================
______________________________________________ test_example _______________________________________________
pexpect.exceptions.TIMEOUT: Function <function test_example.<locals>.fn at 0x7fa241f8b0d0> was unsuccessful after the requested 1 second timeout, and was also unsuccessful after being allowed a leeway of 2 seconds.

The above exception was the direct cause of the following exception:

wait_for = <function wait_for.<locals>._wait_for at 0x7fa241ff1670>

    def test_example(wait_for):
        def fn():
            assert x == 1
            assert y == 2
            assert z == 3
    
        x, y, z = 1, 2, 4
>       wait_for(fn, timeout=1, suppress=(AssertionError,))

tests/test_wait_for.py:82: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox/py39/lib/python3.9/site-packages/pytest_netdut/utils.py:88: in _wait_for
    raise exception from timeout
.tox/py39/lib/python3.9/site-packages/pytest_netdut/utils.py:67: in _wait_for
    result, exception = func(), None
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def fn():
        assert x == 1
        assert y == 2
>       assert z == 3
E       assert 4 == 3

tests/test_wait_for.py:79: AssertionError
----------------------------- generated xml file: /src/test-reports/py39.xml ------------------------------
========================================= short test summary info =========================================
FAILED tests/test_wait_for.py::test_example - assert 4 == 3
======================================= 1 failed, 5 passed in 8.40s =======================================
py39: exit 1 (8.62 seconds) /src> pytest -v --junit-xml=test-reports/py39.xml --junit-prefix=py39 tests pid=107
  py39: FAIL code 1 (17.12=setup[8.50]+cmd[8.62] seconds)
  evaluation failed :( (17.18 seconds)
```