### PR TITLE
px.py: Disable ServerAliveInterval to prevent SSH dying during network blips

### DIFF
--- a/src/pytest_netdut/px.py
+++ b/src/pytest_netdut/px.py
@@ -168,7 +168,7 @@ class CLI(Shell):
             # default is whatever TCP timeout at OS level
             # self.args += ['-o ConnectTimeout 10']
             # self.args += ['-o ServerAliveCountMax 3']   # default 3
-            self.args += ["-o ServerAliveInterval 60"]  # default 0
+            # self.args += ["-o ServerAliveInterval 60"]  # default 0
             self.args += ["-p %s" % (o.port or "22")]
             self.args += extra_args
         elif self.cmd in ("tcp", "telnet"):


### PR DESCRIPTION
The addition of ServerAliveInterval=60 in pytest-netdut 0.14.0 correlates with dead SSH connections at the end of a bbtest run (on Birdsville). The failures also seem to correlate with tests being rerun due to network issues. The hypothesis is that the keep-alive messages are not getting through during the network blips, which causes the SSH connection to be killed.